### PR TITLE
docs: add sanitized MCP leak diagnostics for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ flowchart LR
 - [SUPPORT.md](./SUPPORT.md) — Where to ask
 - [ROADMAP.md](./ROADMAP.md) — Roadmap
 - [CHANGELOG.md](./CHANGELOG.md) — Release notes
+- [MCP process-leak diagnostics](./docs/mcp-process-leak-diagnostics.md) — Privacy-preserving macOS evidence collection and mitigation
 
 ---
 

--- a/docs/mcp-process-leak-diagnostics.md
+++ b/docs/mcp-process-leak-diagnostics.md
@@ -1,0 +1,105 @@
+# Diagnosing MCP process leaks on macOS
+
+ZCode can use user-scoped `stdio` MCP servers in every workspace. When a
+workspace or session is created repeatedly, each session may start another MCP
+process tree. If old trees are not terminated, process count, compressed memory,
+and swap can grow until macOS becomes unresponsive.
+
+This guide provides a privacy-preserving way to collect evidence for that
+failure mode. It complements the reports in issues
+[#25](https://github.com/zai-org/feedback/issues/25) and
+[#104](https://github.com/zai-org/feedback/issues/104).
+
+## Collect a sanitized report
+
+Run the collector on the affected Mac before restarting ZCode, if the machine is
+still responsive:
+
+```bash
+python3 tools/collect_macos_mcp_leak_debug.py > zcode-mcp-leak-debug.md
+```
+
+Review the generated Markdown file before sharing it. The collector reports:
+
+- macOS, hardware model, physical memory, and ZCode version;
+- memory pressure, compressed memory, and swap usage;
+- process counts and ZCode descendant RSS using process names only;
+- configured/enabled MCP counts without server names or configuration values;
+- an anonymized `session/create` timeline;
+- allow-listed summary fields from the latest Jetsam and kernel panic reports.
+
+Its allow-listed output schema does **not** include command arguments,
+environment variables, headers, tokens, API URLs, workspace paths, usernames,
+hostnames, IP addresses, session IDs, conversation content, UUIDs, PIDs, or raw
+core files. Unknown transport values and malformed count fields are reduced to
+fixed labels rather than copied into the report.
+
+Raw `.panic`, Jetsam, and kernel core files can contain sensitive information.
+Do not attach them publicly without reviewing them first.
+
+## Signals that indicate a process leak
+
+The following combination is stronger evidence than a single high-memory
+renderer process:
+
+1. The same anonymized workspace has repeated `session/create` entries.
+2. Each create starts the full user-scoped MCP set.
+3. `zcode-cli` has dozens of direct children and a much larger descendant tree.
+4. Closing a session or ZCode does not return Node, npm, Python, or uv processes
+   to their baseline within 60 seconds.
+5. Jetsam shows an active ZCode group plus a ZCode-helper group without a live
+   ZCode root.
+6. Process count, compressed memory, or swap continues to rise while the app is
+   idle.
+
+## Safe temporary mitigation
+
+1. Save work and quit ZCode normally.
+2. Capture the ZCode root and descendants before force-terminating anything.
+3. If cleanup is required, terminate only the captured tree and re-check process
+   identity before sending a signal. Never use broad commands such as
+   `killall node`, `pkill python`, or `pkill -f mcp`.
+4. Back up `~/.zcode/cli/config.json` with permissions restricted to the current
+   user.
+5. Disable user-scoped `stdio` MCP servers while preserving their definitions.
+6. Re-enable only the servers needed by one workspace, in small batches.
+7. Restart one workspace and verify that process count returns to baseline after
+   each session closes.
+
+Where possible, prefer workspace-scoped MCP configuration over making every
+local `stdio` server available to every workspace.
+
+## Product-side fix proposal
+
+The durable fix belongs in ZCode's session and MCP lifecycle implementation:
+
+- Make `session/create` idempotent for a workspace/session identity.
+- Give every MCP process tree an explicit owner and lifecycle state.
+- Reuse one healthy MCP instance per intended scope instead of spawning a new
+  set on every reconnect.
+- Start local MCP trees in an isolated process group.
+- On session close, replacement, app quit, and startup reconciliation, send a
+  graceful shutdown and then terminate the entire owned process group after a
+  bounded timeout.
+- Give MCP children a parent-death signal, pipe, or heartbeat so they self-exit
+  if the supervisor disappears.
+- Reconcile and terminate orphaned MCP groups before restoring workspaces after
+  a crash.
+- Record spawn/stop events with an owner ID and process count, without logging
+  credentials.
+
+## Suggested regression tests
+
+1. Call `session/create` twice for the same workspace and assert that MCP process
+   count does not increase the second time.
+2. Create and close ten sessions and assert that the process count returns to
+   baseline (within `+5` processes or `+10%`) after every cycle.
+3. Crash the session supervisor and assert that all owned MCP children exit
+   within 60 seconds.
+4. Restore multiple workspaces after a simulated app crash and assert that no
+   orphan group survives reconciliation.
+5. Run a two-hour soak test and assert bounded RSS, compressed memory, and swap.
+
+For a 24 GiB Mac, stop the test if one idle ZCode workspace exceeds 6 GiB,
+creates more than 100 new processes in ten minutes, or keeps memory pressure in
+yellow/red for more than 30 seconds.

--- a/tools/collect_macos_mcp_leak_debug.py
+++ b/tools/collect_macos_mcp_leak_debug.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Collect a privacy-preserving ZCode MCP process-leak report on macOS.
+
+The report intentionally excludes command arguments, environment variables,
+absolute paths, network addresses, UUIDs, session IDs, conversation content,
+and raw crash/core files. It uses only the Python standard library.
+"""
+
+import collections
+import datetime as dt
+import ipaddress
+import json
+import os
+from pathlib import Path
+import plistlib
+import re
+import subprocess
+import sys
+
+
+HOME = str(Path.home())
+UUID_RE = re.compile(
+    r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+)
+IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+HEX_RE = re.compile(r"\b0x[0-9a-fA-F]{8,}\b")
+LONG_TOKEN_RE = re.compile(r"\b[A-Za-z0-9_\-]{48,}\b")
+ABSOLUTE_PATH_RE = re.compile(r"(?<![A-Za-z0-9_])/(?:[^\s`|]+)")
+IPV6_RE = re.compile(
+    r"(?<![A-Za-z0-9])(?:[0-9a-fA-F]{0,4}:){2,}"
+    r"[0-9a-fA-F]{0,4}(?:%[A-Za-z0-9_.-]+)?(?![A-Za-z0-9])"
+)
+SAFE_TRANSPORTS = {"stdio", "sse", "http", "streamable-http", "websocket"}
+
+
+def redact_ipv6(match):
+    candidate = match.group(0)
+    address = candidate.split("%", 1)[0]
+    try:
+        ipaddress.ip_address(address)
+    except ValueError:
+        return candidate
+    return "<ip>"
+
+
+def redact(value):
+    text = str(value)
+    if HOME:
+        text = text.replace(HOME, "<home>")
+    text = UUID_RE.sub("<uuid>", text)
+    text = IPV4_RE.sub("<ip>", text)
+    text = IPV6_RE.sub(redact_ipv6, text)
+    text = HEX_RE.sub("<hex>", text)
+    text = LONG_TOKEN_RE.sub("<redacted-token>", text)
+    text = ABSOLUTE_PATH_RE.sub("<absolute-path>", text)
+    return text
+
+
+class Report:
+    def __init__(self):
+        self.lines = []
+
+    def add(self, value=""):
+        self.lines.append(redact(value))
+
+    def section(self, title):
+        self.add()
+        self.add("## " + title)
+
+    def render(self):
+        return "\n".join(self.lines).rstrip() + "\n"
+
+
+def run(args):
+    try:
+        result = subprocess.run(
+            args,
+            check=False,
+            text=True,
+            capture_output=True,
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return result.stdout.strip()
+
+
+def plist_value(path, key):
+    try:
+        with open(path, "rb") as handle:
+            return plistlib.load(handle).get(key, "unknown")
+    except (OSError, plistlib.InvalidFileException):
+        return "unavailable"
+
+
+def gib(value):
+    return float(value) / (1024.0 ** 3)
+
+
+def system_summary(report):
+    report.section("Environment")
+    model = run(["sysctl", "-n", "hw.model"]) or "unavailable"
+    memory = run(["sysctl", "-n", "hw.memsize"])
+    version = run(["sw_vers", "-productVersion"]) or "unavailable"
+    build = run(["sw_vers", "-buildVersion"]) or "unavailable"
+    zcode_version = plist_value(
+        "/Applications/ZCode.app/Contents/Info.plist",
+        "CFBundleShortVersionString",
+    )
+    report.add("| Field | Value |")
+    report.add("|---|---|")
+    report.add("| Hardware model | `{}` |".format(model))
+    if memory.isdigit():
+        report.add("| Physical memory | `{:.2f} GiB` |".format(gib(int(memory))))
+    else:
+        report.add("| Physical memory | `unavailable` |")
+    report.add("| macOS | `{}` (`{}`) |".format(version, build))
+    report.add("| ZCode | `{}` |".format(zcode_version))
+    report.add("| Collected at | `{}` |".format(dt.datetime.now().astimezone().isoformat(timespec="seconds")))
+
+
+def memory_summary(report):
+    report.section("Current memory pressure")
+    swap = run(["sysctl", "vm.swapusage"]) or "unavailable"
+    pressure = run(["memory_pressure", "-Q"]) or "unavailable"
+    top = run(["top", "-l", "1", "-n", "0"])
+    selected = []
+    for line in top.splitlines():
+        if line.startswith("PhysMem:") or line.startswith("VM:") or line.startswith("Processes:"):
+            selected.append(line)
+    report.add("```text")
+    report.add(swap)
+    for line in pressure.splitlines():
+        if "System-wide memory free percentage" in line:
+            report.add(line)
+    for line in selected:
+        report.add(line)
+    report.add("```")
+
+
+def process_snapshot():
+    output = run(["ps", "-axo", "pid=,ppid=,rss=,etime=,ucomm="])
+    processes = {}
+    children = collections.defaultdict(list)
+    for line in output.splitlines():
+        parts = line.strip().split(None, 4)
+        if len(parts) != 5:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+            rss_kib = int(parts[2])
+        except ValueError:
+            continue
+        processes[pid] = {
+            "ppid": ppid,
+            "rss_kib": rss_kib,
+            "etime": parts[3],
+            "name": parts[4].strip(),
+        }
+        children[ppid].append(pid)
+    return processes, children
+
+
+def descendants(root, children):
+    seen = set()
+    stack = list(children.get(root, []))
+    while stack:
+        pid = stack.pop()
+        if pid in seen:
+            continue
+        seen.add(pid)
+        stack.extend(children.get(pid, []))
+    return seen
+
+
+def process_category(name):
+    lowered = name.lower()
+    if lowered.startswith("zcode helper"):
+        return "ZCode Helper"
+    if lowered == "zcode-cli":
+        return "zcode-cli"
+    if lowered.startswith("zcode-host"):
+        return "zcode-host"
+    if lowered == "node":
+        return "node"
+    if lowered in ("npm", "npx"):
+        return lowered
+    if lowered.startswith("python"):
+        return "python"
+    if lowered in ("uv", "uvx"):
+        return lowered
+    if lowered == "codex":
+        return "codex"
+    if lowered.startswith("chatgpt"):
+        return "ChatGPT"
+    return "other"
+
+
+def process_summary(report):
+    report.section("Process summary (names only; no command arguments)")
+    processes, children = process_snapshot()
+    counts = collections.Counter(process_category(item["name"]) for item in processes.values())
+    interesting = ("ZCode Helper", "zcode-cli", "zcode-host", "node", "npm", "npx", "python", "uv", "uvx", "codex", "ChatGPT")
+    report.add("- Total processes: `{}`".format(len(processes)))
+    report.add("- Selected process counts: `{}`".format(
+        ", ".join("{}={}".format(name, counts.get(name, 0)) for name in interesting)
+    ))
+
+    roots = []
+    for pid, item in processes.items():
+        if item["name"] in ("ZCode", "zcode-cli", "ChatGPT", "codex"):
+            roots.append((pid, item))
+
+    report.add()
+    report.add("| Root name | Elapsed | Direct children | Descendants | Descendant RSS | Top descendant types |")
+    report.add("|---|---:|---:|---:|---:|---|")
+    for pid, item in sorted(roots, key=lambda row: (row[1]["name"], row[0])):
+        tree = descendants(pid, children)
+        if not tree and item["name"] not in ("ZCode", "ChatGPT"):
+            continue
+        rss_kib = sum(processes[child]["rss_kib"] for child in tree if child in processes)
+        tree_counts = collections.Counter(
+            process_category(processes[child]["name"])
+            for child in tree
+            if child in processes
+        )
+        top_types = ", ".join(
+            "{}x{}".format(name, count)
+            for name, count in tree_counts.most_common(8)
+            if name != "other"
+        ) or "none"
+        report.add(
+            "| `{}` | `{}` | {} | {} | `{:.2f} GiB` | {} |".format(
+                item["name"],
+                item["etime"],
+                len(children.get(pid, [])),
+                len(tree),
+                rss_kib / (1024.0 ** 2),
+                top_types,
+            )
+        )
+
+
+def zcode_config_summary(report):
+    report.section("ZCode MCP configuration summary")
+    path = Path.home() / ".zcode" / "cli" / "config.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        servers = data.get("mcp", {}).get("servers", {})
+    except (OSError, ValueError, AttributeError):
+        report.add("Configuration could not be parsed.")
+        return
+    if not isinstance(servers, dict):
+        report.add("Configuration does not contain a valid MCP server map.")
+        return
+    valid = [value for value in servers.values() if isinstance(value, dict)]
+    enabled = [value for value in valid if value.get("enabled", True) is True]
+    transports = collections.Counter()
+    for value in valid:
+        raw_transport = value.get("type", "unspecified")
+        transport = raw_transport.lower() if isinstance(raw_transport, str) else "other"
+        transports[transport if transport in SAFE_TRANSPORTS else "other"] += 1
+    report.add("- Configured MCP servers: `{}`".format(len(servers)))
+    report.add("- Enabled MCP servers: `{}`".format(len(enabled)))
+    if len(valid) != len(servers):
+        report.add("- Invalid server entries: `{}`".format(len(servers) - len(valid)))
+    report.add("- Transport counts: `{}`".format(dict(sorted(transports.items()))))
+    report.add("- Server names, commands, arguments, environment variables, and credentials are intentionally omitted.")
+
+
+def session_create_summary(report):
+    report.section("Sanitized session/create timeline")
+    log_path = Path.home() / ".zcode" / "v2" / "logs" / (dt.date.today().isoformat() + ".log")
+    workspace_labels = {}
+    events = []
+    try:
+        lines = log_path.open("r", encoding="utf-8", errors="replace")
+    except OSError:
+        report.add("No readable ZCode log was found for today.")
+        return
+    with lines:
+        for line in lines:
+            if "session/create" not in line or '"hasInitialModel"' not in line:
+                continue
+            start = line.find("{")
+            if start < 0:
+                continue
+            try:
+                payload = json.loads(line[start:])
+            except ValueError:
+                continue
+            workspace = payload.get("workspacePath") or payload.get("workspaceKey") or "unknown"
+            if workspace not in workspace_labels:
+                workspace_labels[workspace] = "workspace-{}".format(len(workspace_labels) + 1)
+            timestamp_match = re.search(r"\[(\d{4}-\d{2}-\d{2} [0-9:.]+)\]", line)
+            events.append(
+                (
+                    timestamp_match.group(1) if timestamp_match else "unknown",
+                    workspace_labels[workspace],
+                    (
+                        payload.get("mcpServerCount")
+                        if isinstance(payload.get("mcpServerCount"), int)
+                        and not isinstance(payload.get("mcpServerCount"), bool)
+                        else "unknown"
+                    ),
+                )
+            )
+    report.add("- Session-create requests today: `{}` across `{}` anonymized workspaces.".format(
+        len(events), len(workspace_labels)
+    ))
+    report.add()
+    report.add("| Timestamp | Workspace label | MCP server count |")
+    report.add("|---|---|---:|")
+    for timestamp, workspace, count in events[-30:]:
+        report.add("| `{}` | `{}` | {} |".format(timestamp, workspace, count))
+    report.add()
+    report.add("Workspace paths, model/provider details, URLs, trace IDs, and session IDs are omitted.")
+
+
+def split_json_report(path):
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        handle.readline()
+        return json.load(handle)
+
+
+def report_candidates(pattern):
+    root = Path("/Library/Logs/DiagnosticReports")
+    candidates = []
+    try:
+        candidates.extend(root.glob(pattern))
+        candidates.extend((root / "Retired").glob(pattern))
+    except OSError:
+        return []
+    readable = []
+    for path in candidates:
+        try:
+            readable.append((path.stat().st_mtime, path))
+        except OSError:
+            continue
+    return [path for _mtime, path in sorted(readable, reverse=True)]
+
+
+def latest_report(pattern):
+    candidates = report_candidates(pattern)
+    return candidates[0] if candidates else None
+
+
+def jetsam_summary(report):
+    path = latest_report("JetsamEvent*.ips")
+    if path is None:
+        return
+    try:
+        data = split_json_report(path)
+    except (OSError, ValueError):
+        return
+    report.section("Latest Jetsam snapshot (sanitized)")
+    try:
+        page_size = int(data.get("memoryStatus", {}).get("pageSize", 16384))
+    except (TypeError, ValueError):
+        page_size = 16384
+    processes = data.get("processes", [])
+    active = [item for item in processes if "active" in item.get("states", [])]
+    report.add("- Snapshot time: `{}`".format(data.get("date", "unknown")))
+    report.add("- Active process records: `{}`".format(len(active)))
+    largest = process_category(data.get("largestProcess", ""))
+    if largest == "other":
+        largest = "other (name omitted)"
+    report.add("- Largest process class: `{}`".format(largest))
+
+    aggregates = collections.defaultdict(lambda: [0, 0])
+    for item in active:
+        name = item.get("name", "")
+        label = None
+        if name == "node":
+            label = "node"
+        elif name.startswith("python"):
+            label = "python"
+        elif name in ("uv", "uvx", "npm", "npx", "codex", "ChatGPT", "ZCode"):
+            label = name
+        elif name.startswith("ZCode Helper"):
+            label = "ZCode Helper"
+        if label:
+            aggregates[label][0] += 1
+            try:
+                aggregates[label][1] += int(item.get("rpages") or 0)
+            except (TypeError, ValueError):
+                pass
+
+    report.add()
+    report.add("| Process class | Count | Aggregate footprint |")
+    report.add("|---|---:|---:|")
+    for name, (count, pages) in sorted(aggregates.items(), key=lambda row: row[1][1], reverse=True):
+        report.add("| `{}` | {} | `{:.2f} GiB` |".format(name, count, gib(pages * page_size)))
+
+    coalitions = collections.defaultdict(list)
+    for item in active:
+        coalitions[item.get("coalition")].append(item)
+    app_groups = []
+    for members in coalitions.values():
+        names = [item.get("name", "") for item in members]
+        label = None
+        if "ZCode" in names:
+            label = "ZCode current group"
+        elif any(name.startswith("ZCode Helper") for name in names):
+            label = "ZCode orphan candidate"
+        elif "ChatGPT" in names:
+            label = "ChatGPT/Codex group"
+        if label:
+            pages = 0
+            for item in members:
+                try:
+                    pages += int(item.get("rpages") or 0)
+                except (TypeError, ValueError):
+                    pass
+            app_groups.append((label, len(members), pages))
+    if app_groups:
+        report.add()
+        report.add("| Anonymized app group | Active processes | Aggregate footprint |")
+        report.add("|---|---:|---:|")
+        for label, count, pages in sorted(app_groups, key=lambda row: row[2], reverse=True):
+            report.add("| {} | {} | `{:.2f} GiB` |".format(label, count, gib(pages * page_size)))
+
+
+def panic_summary(report):
+    data = None
+    for path in report_candidates("*.panic"):
+        try:
+            candidate = split_json_report(path)
+        except (OSError, ValueError):
+            continue
+        if candidate.get("panicString"):
+            data = candidate
+            break
+    if data is None:
+        return
+    panic = data.get("panicString", "")
+    watchdog = re.search(
+        r"watchdog timeout: no checkins from watchdogd in \d+ seconds",
+        panic,
+    )
+    compressor = re.search(
+        r"Compressor Info: \d+% of compressed pages limit \([A-Z]+\) and "
+        r"\d+% of segments limit \([A-Z]+\) with \d+ swapfiles and "
+        r"[A-Z]+ swap space",
+        panic,
+    )
+    calendar = re.search(r"Calendar:\s+0x([0-9a-fA-F]+)", panic)
+    report.section("Latest kernel panic (sanitized)")
+    if calendar:
+        try:
+            timestamp = dt.datetime.fromtimestamp(int(calendar.group(1), 16)).astimezone()
+            report.add("- Panic time: `{}`".format(timestamp.isoformat(timespec="seconds")))
+        except (OverflowError, OSError, ValueError):
+            pass
+    if watchdog:
+        report.add("- `{}`".format(watchdog.group(0)))
+    if compressor:
+        report.add("- `{}`".format(compressor.group(0)))
+    report.add("- Kernel addresses, UUIDs, incident IDs, crash reporter keys, and raw core data are omitted.")
+
+
+def privacy_note(report):
+    report.section("Privacy boundary")
+    report.add("This report does not contain:")
+    report.add("- usernames, hostnames, IP addresses, or absolute home/workspace paths;")
+    report.add("- MCP names, commands, arguments, environment variables, headers, tokens, or API URLs;")
+    report.add("- conversation titles/content, session IDs, trace IDs, UUIDs, PIDs, or raw crash/core data.")
+
+
+def main():
+    if sys.platform != "darwin":
+        print("This collector is intended for macOS.", file=sys.stderr)
+        return 2
+    report = Report()
+    report.add("# Sanitized ZCode MCP process-leak debug report")
+    report.add()
+    report.add("Generated locally. Review the output before posting it publicly.")
+    system_summary(report)
+    memory_summary(report)
+    process_summary(report)
+    zcode_config_summary(report)
+    session_create_summary(report)
+    jetsam_summary(report)
+    panic_summary(report)
+    privacy_note(report)
+    sys.stdout.write(report.render())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- adds a standard-library-only macOS collector for privacy-preserving MCP process-leak reports;
- adds a diagnostic guide covering evidence interpretation, safe mitigation, product-side lifecycle fixes, and regression tests;
- links the guide from the feedback hub README.

## Why

Issues #25 and #104 describe `session/create` or session shutdown leaving repeated local MCP process trees alive. Raw `ps` output, MCP configuration, ZCode logs, panic reports, and kernel cores can contain paths, credentials, URLs, session identifiers, and conversation context, which makes it difficult for users to share useful evidence safely.

The collector emits only allow-listed aggregate fields and anonymized workspace labels. Its output schema does not include command arguments, environment variables, server names, tokens, API URLs, absolute paths, PIDs, UUIDs, or raw crash/core data; unknown transport values and malformed count fields become fixed labels.

## Impact

Users can generate a high-signal Markdown report without manually publishing sensitive local state. Maintainers get consistent process counts, descendant RSS, MCP counts, anonymized `session/create` timelines, and safe Jetsam/panic summaries.

This PR is diagnostic documentation and tooling for the public feedback repository. It does not claim to patch the closed-source ZCode client.

## Root cause addressed by the guidance

Repeated session creation can spawn a complete user-scoped `stdio` MCP set while older process groups remain alive. The guide proposes idempotent session creation, explicit process ownership, process-group cleanup, parent-death signaling, startup orphan reconciliation, and bounded regression/soak tests.

## Validation

- `python -m py_compile tools/collect_macos_mcp_leak_debug.py`
- ran the collector on macOS 26.6 with ZCode 3.3.3
- manually verified the generated report contains no username, hostname, IP address, absolute home/workspace path, MCP name/command/argument/environment, credential, API URL, session/trace ID, UUID, PID, conversation content, or raw core data
